### PR TITLE
[rfc] do not hold on to records

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ovotech/kafka-clj-utils "2.0.1-1"
+(defproject ovotech/kafka-clj-utils "2.0.1-2"
   :description "Clojure utilities for Kafka"
   :url "https://github.com/ovotech/kafka-clj-utils"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
- do not hold on to failed records `r`; if they are large, logging
the exception out takes up considerable resources
- do not hold on to `records` in the `assert-not-failed!` closure;